### PR TITLE
Update device_type generation and jq template for transform is_.jq

### DIFF
--- a/frontend/src/mixins/mixin-Shared-BuildJq.js
+++ b/frontend/src/mixins/mixin-Shared-BuildJq.js
@@ -18,6 +18,7 @@ export default {
         .replace(/{{EZ_stream_name_placeholder}}/g, pipelineName)
         .replace(/{{EZ_stream_id_placeholder}}/g, pipelineUid)
         .replace(/{{EZ_compact_stream_name_placeholder}}/g, String(pipelineName).replace(/[^a-zA-Z0-9]/g, '_').toLowerCase())
+        .replace(/{{EZ_device_name_placeholder}}/g, beatName)
         .replace(/{{EZ_beat_name_placeholder}}/g, beatName)
 
       // And ship it back
@@ -34,6 +35,7 @@ export default {
         .replace(/{{EZ_stream_name_placeholder}}/g, pipelineName)
         .replace(/{{EZ_stream_id_placeholder}}/g, pipelineUid)
         .replace(/{{EZ_compact_stream_name_placeholder}}/g, String(pipelineName).replace(/[^a-zA-Z0-9]/g, '_').toLowerCase())
+        .replace(/{{EZ_device_name_placeholder}}/g, beatName)
         .replace(/{{EZ_beat_name_placeholder}}/g, beatName)
 
       // What do we use for original_message?

--- a/frontend/src/store/mainStore/templates/jqTemplates.js
+++ b/frontend/src/store/mainStore/templates/jqTemplates.js
@@ -21,9 +21,9 @@ def is_matching:
       or
       ."@metadata".device_type == "{{EZ_compact_stream_name_placeholder}}"
       or
-      .device_type == "{{EZ_stream_name_placeholder}}"
+      (.device_type | ascii_downcase) == ("{{EZ_device_name_placeholder}}" | ascii_downcase)
       or
-      .device_type == "{{EZ_compact_stream_name_placeholder}}"
+      (.device_type | ascii_downcase) == "{{EZ_compact_stream_name_placeholder}}"
     )
 ;
 `


### PR DESCRIPTION
device_type conventionally shows the same as the beat_type.  The current schema applied prevents Webhook beat transforms from being applicable.

This behavior is pretty normal for LR beats.  Not sure if carried over to previous uses of File beat or jsBeat.