### PR TITLE
Backend - Fix #17 - Upgrade to v0.9.7 fails to update `openCollectors` table correctly

### DIFF
--- a/database/20210430.01 - Create Table - openCollectors.sql
+++ b/database/20210430.01 - Create Table - openCollectors.sql
@@ -55,6 +55,5 @@ BEGIN
 		PRINT CONVERT(nvarchar(24), GETDATE(), 121) + ' | INFO: Adding column [dockerVersion] to table [openCollectors].'
 		ALTER TABLE dbo.openCollectors ADD dockerVersion nvarchar(100) NULL
 	END
-	GO
 END
 GO


### PR DESCRIPTION
Fix small bug affecting users upgrading from v0.9.x to v0.9.7.
The Docker Version column in `openCollectors` table wasn't added correctly.
Fixes Issue #17 .