### PR TITLE
Docker.oc admin dev.docker in container

### DIFF
--- a/docker/oc-admin_dev/Dockerfile
+++ b/docker/oc-admin_dev/Dockerfile
@@ -6,6 +6,7 @@
 # Modified on: 2022-12-02 - Change branch to v1.0, expose 8080 too
 # Modified on: 2023-01-04 - Remove option to do a full build for Docker via Environment variable
 # Modified on: 2023-01-04 - Break down Init, Run and Build into different entrypoint scripts
+# Modified on: 2023-01-11 - Add Docker to container, as a fundation to build and publish Docker images from container itself
 # Description: Describe container `oc-admin_dev`, based on NodeJS
 #              This container is designed to develop, as opposed
 #              to run, the OC Admin (formerly EZ Cloud) Backend,
@@ -18,6 +19,7 @@ RUN apk update
 RUN apk add git
 RUN apk add uuidgen
 RUN apk add zip
+RUN apk add docker
 
 WORKDIR /app
 

--- a/docker/oc-admin_dev/_docker.run-oc-admin_dev.sh
+++ b/docker/oc-admin_dev/_docker.run-oc-admin_dev.sh
@@ -6,6 +6,7 @@
 # Modified on: 2022-07-13 - To increase user watches, instances and queued events limits on the Docker host
 # Modified on: 2022-12-02 - To start container in auto-restart, and tail logs instead of running in interactive mode
 # Modified on: 2023-01-04 - To start container in build mode using specific entrypoint instead of environment variable
+# Modified on: 2023-01-11 - Add Docker to container, as a fundation to build and publish Docker images from container itself
 # Description: Pull and Start Dev version of the OC-Admin container `oc-admin_dev`.
 #              Can be used to just build the content of the `oc-admin` container, with the `--build_only` flag.
 # Parameters:
@@ -41,7 +42,7 @@ if [[ "$*" == *build_only* ]]; then
 
   echo "### RUN CONTAINER IN BUILING MODE..."
   # docker run --interactive --tty --rm --volume oc-admin_dev:/app/EZ-Cloud/dist --env BUILD_OC_ADMIN_IMAGE="TRUE" tonymasse/oc-admin_dev
-  docker run --interactive --tty --rm --volume oc-admin_dev:/app/EZ-Cloud/dist --entrypoint="/app/_entrypoint.buildDockerFull.sh" tonymasse/oc-admin_dev
+  docker run --interactive --tty --rm --volume oc-admin_dev:/app/EZ-Cloud/dist --volume /var/run/docker.sock:/var/run/docker.sock --entrypoint="/app/_entrypoint.buildDockerFull.sh" tonymasse/oc-admin_dev
 
 else
 
@@ -62,7 +63,7 @@ else
   # echo "### RUN CONTAINER IN INTERACTIVE MODE..."
   # docker run --interactive --tty --publish 8400:8400/tcp --network logrhythm --volume oc-admin_dev:/app/EZ-Cloud/dist --name oc-admin tonymasse/oc-admin_dev
   echo "### START CONTAINER..."
-  docker run --detach --restart unless-stopped --tty --publish 8400:8400/tcp --network logrhythm --volume oc-admin_dev:/app/EZ-Cloud/dist --name oc-admin tonymasse/oc-admin_dev
+  docker run --detach --restart unless-stopped --tty --publish 8400:8400/tcp --network logrhythm --volume oc-admin_dev:/app/EZ-Cloud/dist --volume /var/run/docker.sock:/var/run/docker.sock --name oc-admin tonymasse/oc-admin_dev
 
   echo "### FOLLOW CONTAINER'S LOGS..."
   docker logs --follow oc-admin


### PR DESCRIPTION
To be able to eventually Build and Publish OC-Admin and OC-DB containers straight from inside the `oc-admin_dev` container.